### PR TITLE
updated naming conventions for column headers

### DIFF
--- a/src/components/display/display.js
+++ b/src/components/display/display.js
@@ -147,11 +147,11 @@ const Display = (props) => {
               <thead>
                 <tr>
                   <th>Row #</th>
-                  <th>Section ID</th>
-                  <th>X-slope</th>
-                  <th>Y-slope</th>
-                  <th>Latitude</th>
-                  <th>Longitude</th>
+                  <th>Sidewalk ID</th>
+                  <th>Cross Slope (°)</th>
+                  <th>Running Slope (°)</th>
+                  <th>Latitude (°)</th>
+                  <th>Longitude (°)</th>
                   <th>Image</th>
                 </tr>
               </thead>


### PR DESCRIPTION
This PR updates the display table in display.js to use corrected naming conventions for slope and coordinate columns. 